### PR TITLE
Remove redundant citas import in backend main module

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,5 @@
 from fastapi import FastAPI
 from backend.routes import auth, citas
-from backend.routes import citas
-
-
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- remove duplicate `citas` import from `backend/main.py`

## Testing
- `pytest -q`
- `uvicorn backend.main:app --host 127.0.0.1 --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_68995df0c01c832386861d207b1d2f73