### PR TITLE
feat: centralize email validation

### DIFF
--- a/apps/dentista/views/login_dentista.py
+++ b/apps/dentista/views/login_dentista.py
@@ -1,27 +1,9 @@
 import flet as ft
-import re
 import httpx
 from common import colors
-from typing import Tuple
+from common.validators import validar_email
 
 API_LOGIN_URL = "http://localhost:8000/api/usuarios/login"
-
-def validar_email(email: str) -> Tuple[bool, str]:
-    pattern = r'^[\w\.-]+@([\w\.-]+\.\w+)$'
-    match = re.match(pattern, email)
-    if not match:
-        return False, "Correo electrónico no válido"
-    dominio = email.split('@')[1].lower()
-    dominios_prohibidos = {
-        "gmai.com": "¿Quisiste decir gmail.com?",
-        "hotmial.com": "¿Quisiste decir hotmail.com?",
-        "yaho.com": "¿Quisiste decir yahoo.com?",
-        "outlok.com": "¿Quisiste decir outlook.com?",
-        "gmal.com": "¿Quisiste decir gmail.com?"
-    }
-    if dominio in dominios_prohibidos:
-        return False, dominios_prohibidos[dominio]
-    return True, ""
 
 def LoginDentistaView(page: ft.Page):
     email_input = ft.TextField(

--- a/apps/dentista/views/registro_dentista.py
+++ b/apps/dentista/views/registro_dentista.py
@@ -1,30 +1,10 @@
 import flet as ft
-import re
 import requests
-from typing import Tuple
 from common import colors
+from common.validators import validar_email
 
 API_REGISTER_URL = "http://localhost:8000/api/usuarios/registrar"
 
-def validar_email(email: str) -> Tuple[bool, str]:
-    pattern = r'^[\w\.-]+@([\w\.-]+\.\w+)$'
-    match = re.match(pattern, email)
-    if not match:
-        return False, "Correo electrónico no válido"
-
-    dominio = email.split('@')[1].lower()
-    dominios_prohibidos = {
-        "gmai.com": "¿Quisiste decir gmail.com?",
-        "hotmial.com": "¿Quisiste decir hotmail.com?",
-        "yaho.com": "¿Quisiste decir yahoo.com?",
-        "outlok.com": "¿Quisiste decir outlook.com?",
-        "gmal.com": "¿Quisiste decir gmail.com?"
-    }
-
-    if dominio in dominios_prohibidos:
-        return False, dominios_prohibidos[dominio]
-
-    return True, ""
 
 def RegistroDentistaView(page: ft.Page):
     nombre_input = ft.TextField(label="Nombre", width=300, border_color=colors.PRIMARY, focused_border_color=colors.PRIMARY_DARK)

--- a/common/validators.py
+++ b/common/validators.py
@@ -1,0 +1,29 @@
+import re
+from typing import Tuple
+
+
+def validar_email(email: str) -> Tuple[bool, str]:
+    """Valida el formato y el dominio de un correo electrónico.
+
+    Args:
+        email: Correo electrónico a validar.
+
+    Returns:
+        Tuple con un booleano que indica si es válido y un mensaje de error.
+    """
+    pattern = r'^[\w\.-]+@([\w\.-]+\.\w+)$'
+    match = re.match(pattern, email)
+    if not match:
+        return False, "Correo electrónico no válido"
+
+    dominio = email.split('@')[1].lower()
+    dominios_prohibidos = {
+        "gmai.com": "¿Quisiste decir gmail.com?",
+        "hotmial.com": "¿Quisiste decir hotmail.com?",
+        "yaho.com": "¿Quisiste decir yahoo.com?",
+        "outlok.com": "¿Quisiste decir outlook.com?",
+        "gmal.com": "¿Quisiste decir gmail.com?",
+    }
+    if dominio in dominios_prohibidos:
+        return False, dominios_prohibidos[dominio]
+    return True, ""

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from common.validators import validar_email
+
+
+def test_email_valido():
+    assert validar_email("usuario@example.com") == (True, "")
+
+
+def test_email_formato_invalido():
+    valido, mensaje = validar_email("usuarioexample.com")
+    assert not valido
+    assert mensaje == "Correo electrónico no válido"
+
+
+def test_email_dominios_sugeridos():
+    valido, mensaje = validar_email("usuario@gmai.com")
+    assert not valido
+    assert mensaje == "¿Quisiste decir gmail.com?"


### PR DESCRIPTION
## Summary
- move email validation logic into common validators module
- use shared validator in dentist login and registration views
- add basic unit tests for email validator

## Testing
- `pytest tests/test_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68995e095fc08323ae8c657fb85a14f4